### PR TITLE
Support colon character

### DIFF
--- a/tests/m5stack/lcd.py
+++ b/tests/m5stack/lcd.py
@@ -43,8 +43,11 @@ def screensize():
 def get_fg():
     return WHITE
 
-def triangle(x, y, x1, y1, color, fillcolor=None):
+def triangle(x, y, x1, y1, color=None, fillcolor=None):
     pass
 
-def rect(x, y, w, h, color, fillcolor=None):
+def rect(x, y, w, h, color=None, fillcolor=None):
+    pass
+
+def circle(x, y, r, color=None, fillcolor=None):
     pass

--- a/tests/test_font16seg.py
+++ b/tests/test_font16seg.py
@@ -109,6 +109,30 @@ class TestFont16seg(unittest.TestCase):
         lcd.triangle.assert_not_called()
         lcd.rect.assert_not_called()
 
+    def test_text_with_colon(self):
+        lcd.screensize = MagicMock(return_value=(136, 241))
+        lcd.triangle = MagicMock()
+        lcd.rect = MagicMock()
+        lcd.circle = MagicMock()
+
+        font16seg.attrib16seg(8, 2, lcd.WHITE, unlit_color=None)
+        font16seg.text(0, 0, "0:0")
+        self.assertEqual(lcd.triangle.call_count, 40)
+        self.assertEqual(lcd.rect.call_count, 16)
+        self.assertEqual(lcd.circle.call_count, 2)
+
+    def test_text_with_semi_colon(self):
+        lcd.screensize = MagicMock(return_value=(136, 241))
+        lcd.triangle = MagicMock()
+        lcd.rect = MagicMock()
+        lcd.circle = MagicMock()
+
+        font16seg.attrib16seg(8, 2, lcd.WHITE, unlit_color=None)
+        font16seg.text(0, 0, "0;0")
+        self.assertEqual(lcd.triangle.call_count, 40)
+        self.assertEqual(lcd.rect.call_count, 16)
+        lcd.circle.assert_not_called()
+
     def test_fontSize(self):
         font16seg.attrib16seg(10, 8, lcd.WHITE)
         self.assertEqual(font16seg.fontSize(), (46, 72))
@@ -132,3 +156,11 @@ class TestFont16seg(unittest.TestCase):
     def test_textWidth_with_unsupported_characters(self):
         font16seg.attrib16seg(10, 8, lcd.WHITE, letter_spacing=2)
         self.assertEqual(font16seg.textWidth("0#!1?@"), 46*6+2*5)
+
+    def test_textWidth_with_colon(self):
+        font16seg.attrib16seg(10, 8, lcd.WHITE, letter_spacing=2)
+        self.assertEqual(font16seg.textWidth("00:00"), 46*4+8+2*4)
+
+    def test_textWidth_with_colon_only(self):
+        font16seg.attrib16seg(10, 8, lcd.WHITE, letter_spacing=1)
+        self.assertEqual(font16seg.textWidth(":"), 8)


### PR DESCRIPTION
Support colon character.

font16seg now supports to display colon character.
If semi-colon is given, display the colon with the unlit color.

-----
on M5stickC Plus

```python
from m5stack import lcd
import font16seg

lcd.orient(lcd.LANDSCAPE)

font16seg.attrib16seg(8, 6, lcd.WHITE, unlit_color=0x202020)
font16seg.text(39,  8, "01:23")
font16seg.text(39, 70, "45;67")
```
![font16seg_colon](https://user-images.githubusercontent.com/359700/233779895-a5833624-5d24-495c-9167-b49f9292cf0f.jpg)
